### PR TITLE
Feat/#4 '로그' 메뉴 분리 / 메뉴 중앙 정렬

### DIFF
--- a/src/app/log/[category]/page.tsx
+++ b/src/app/log/[category]/page.tsx
@@ -1,0 +1,13 @@
+import { StickyToolbar } from "@/components";
+import ItemListDeck from "@/components/lists";
+
+const GalleryCategory = () => {
+  return (
+    <div className="mt-8 h-[1500px] w-full">
+      <StickyToolbar />
+      <ItemListDeck />
+    </div>
+  );
+};
+
+export default GalleryCategory;

--- a/src/app/log/layout.tsx
+++ b/src/app/log/layout.tsx
@@ -1,4 +1,4 @@
-import TabbarDeck from "@/components/common/tabbar";
+import { Tabbar } from "@/components";
 import { menus } from "@/constants/menuTree";
 
 interface TabLayoutProps {
@@ -6,15 +6,11 @@ interface TabLayoutProps {
 }
 
 const TabLayout = ({ children }: TabLayoutProps) => {
-  const GALLERY = menus[4];
+  const LOG = menus[5];
 
   return (
     <div className="mt-16 h-full w-full flex-1 px-layout">
-      <TabbarDeck
-        page={GALLERY.title}
-        pageUrl={GALLERY.url}
-        subMenu={GALLERY.subMenu ?? []}
-      />
+      <Tabbar page={LOG.title} pageUrl={LOG.url} subMenu={LOG.subMenu ?? []} />
       {children}
     </div>
   );

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -1,0 +1,13 @@
+import { StickyToolbar } from "@/components";
+import ItemListDeck from "@/components/lists";
+
+const Log = () => {
+  return (
+    <div className="mt-8 h-[1500px] w-full">
+      <StickyToolbar />
+      <ItemListDeck />
+    </div>
+  );
+};
+
+export default Log;

--- a/src/app/work/[category]/page.tsx
+++ b/src/app/work/[category]/page.tsx
@@ -1,9 +1,8 @@
-import { StickyToolbar } from "@/components";
-import ItemListDeck from "@/components/lists";
+import { ItemListDeck, StickyToolbar } from "@/components";
 
 const WorkCategory = () => {
   return (
-    <div className="mt-8 h-[500px] w-full bg-red">
+    <div className="mt-8 h-[1500px] w-full">
       <StickyToolbar />
       <ItemListDeck />
     </div>

--- a/src/app/work/layout.tsx
+++ b/src/app/work/layout.tsx
@@ -6,7 +6,7 @@ interface TabLayoutProps {
 }
 
 const TabLayout = ({ children }: TabLayoutProps) => {
-  const WORK = menus[2];
+  const WORK = menus[3];
 
   return (
     <div className="mt-16 h-full w-full flex-1 px-layout">

--- a/src/components/common/stickyToolbar/index.tsx
+++ b/src/components/common/stickyToolbar/index.tsx
@@ -8,19 +8,16 @@ import { HEADER_SCROLL } from "@/constants/scroll";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/navigation";
 import { twMerge } from "tailwind-merge";
+import useQueryProps from "@/hooks/useQueryProps";
 
 const StickyToolbar = () => {
   const { majorPathInfo, fullPathname, minorPathname } = usePathProps();
+  const { list, sort } = useQueryProps();
+
   const router = useRouter();
   const handleNavigation = (path: string) => {
     router.push(path);
   };
-
-  const searchParams = useSearchParams();
-  const list = searchParams.get("list");
-  const sort = searchParams.get("sort");
-
-  console.log(list, "list");
 
   const listViewStyle =
     list === "list" || !list ? "text-white" : "text-gray-400";

--- a/src/components/common/stickyToolbar/index.tsx
+++ b/src/components/common/stickyToolbar/index.tsx
@@ -81,6 +81,7 @@ const StickyToolbar = () => {
         {majorPathInfo?.subMenu?.map((item) => (
           <Link
             key={item.title}
+            prefetch={true}
             className={twMerge(
               "text-14",
               item.url === minorPathname ? "text-white" : "text-gray-400",

--- a/src/components/common/tabbar/index.tsx
+++ b/src/components/common/tabbar/index.tsx
@@ -18,7 +18,7 @@ const Category = ({ children, url, pageUrl, isFocused }: TabProps) => {
   return (
     <Link
       href={pageUrl + url}
-      className={`flex h-full flex-grow items-center justify-center rounded-12 border border-gray-400 text-14 text-white ${focusStyle}`}
+      className={`flex h-full flex-1 items-center justify-center rounded-12 border border-gray-400 text-14 text-white ${focusStyle}`}
     >
       {children}
     </Link>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -11,15 +11,17 @@ import { FiBookOpen as BookIcon } from "react-icons/fi";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { HEADER_SCROLL } from "@/constants/scroll";
-import { twMerge } from "tailwind-merge";
 import usePathProps from "@/hooks/usePathProps";
+import Logo from "./logo";
+import { twMerge } from "tailwind-merge";
 
 const Header = () => {
   const LOGOMENU = menus[0];
   const GUESTBOOK = menus[1];
-  const WORK = menus[2];
-  const GALLERY = menus[3];
-  const SIGNIN = menus[4];
+  const SIGNIN = menus[2];
+  const WORK = menus[3];
+  const GALLERY = menus[4];
+  const LOG = menus[5];
 
   const [headerHeight, setHeaderHeight] = useState<"44px" | "88px">("44px");
   const { majorPathname } = usePathProps();
@@ -43,43 +45,49 @@ const Header = () => {
 
   return (
     <div className="fixed top-0 z-10 flex w-screen flex-col px-layout pt-layout">
+      {/* Actual Contaniner Below */}
       <div
         className="flex w-full justify-center rounded-12 bg-gray-700 transition-all"
         style={{ height: headerHeight }}
       >
-        {/* Upper */}
         <div className="flex h-header w-full items-center">
-          <div className="flex h-full w-1/4 items-center justify-start pl-header-margin">
+          <div className="flex h-full w-2/5 flex-1 items-center justify-start gap-4 pl-header-margin">
             <MenuIcon color="white" size={24} />
+            <Logo />
           </div>
-          <div className="flex w-1/2 justify-between text-14">
+          <div className="flex w-[300px] justify-between text-14">
             <Link
               prefetch={true}
               href={WORK.url}
-              className={
-                majorPathname === WORK.url ? "text-white" : "text-gray-400"
-              }
+              className={twMerge(
+                "w-20",
+                majorPathname === WORK.url ? "text-white" : "text-gray-400",
+              )}
             >
               {WORK.title}
-            </Link>
-            <Link
-              prefetch={true}
-              href={LOGOMENU.url}
-              className="font-semibold text-white"
-            >
-              {LOGOMENU.as}
             </Link>
             <Link //
               prefetch={true}
               href={GALLERY.url}
-              className={
-                majorPathname === GALLERY.url ? "text-white" : "text-gray-400"
-              }
+              className={twMerge(
+                "flex w-20 justify-center",
+                majorPathname === GALLERY.url ? "text-white" : "text-gray-400",
+              )}
             >
               {GALLERY.title}
             </Link>
+            <Link //
+              prefetch={true}
+              href={LOG.url}
+              className={twMerge(
+                "flex w-20 justify-end",
+                majorPathname === LOG.url ? "text-white" : "text-gray-400",
+              )}
+            >
+              {LOG.title}
+            </Link>
           </div>
-          <div className="flex h-full w-1/4 items-center justify-end gap-5 pr-header-margin">
+          <div className="flex h-full flex-1 items-center justify-end gap-5 pr-header-margin">
             <Link prefetch={true} href={GUESTBOOK.url}>
               <UserIcon color="white" size={22} />
             </Link>
@@ -91,8 +99,6 @@ const Header = () => {
             </button>
           </div>
         </div>
-        {/* Bottom */}
-        <div></div>
       </div>
     </div>
   );

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -11,6 +11,8 @@ import { FiBookOpen as BookIcon } from "react-icons/fi";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { HEADER_SCROLL } from "@/constants/scroll";
+import { twMerge } from "tailwind-merge";
+import usePathProps from "@/hooks/usePathProps";
 
 const Header = () => {
   const LOGOMENU = menus[0];
@@ -20,6 +22,7 @@ const Header = () => {
   const SIGNIN = menus[4];
 
   const [headerHeight, setHeaderHeight] = useState<"44px" | "88px">("44px");
+  const { majorPathname } = usePathProps();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -46,21 +49,41 @@ const Header = () => {
       >
         {/* Upper */}
         <div className="flex h-header w-full items-center">
-          <div className="pl-header-margin flex h-full w-1/4 items-center justify-start">
+          <div className="flex h-full w-1/4 items-center justify-start pl-header-margin">
             <MenuIcon color="white" size={24} />
           </div>
-          <div className="flex w-1/2 justify-between text-14 text-white">
-            <Link href={WORK.url}>{WORK.title}</Link>
-            <Link href={LOGOMENU.url} className="font-semibold">
+          <div className="flex w-1/2 justify-between text-14">
+            <Link
+              prefetch={true}
+              href={WORK.url}
+              className={
+                majorPathname === WORK.url ? "text-white" : "text-gray-400"
+              }
+            >
+              {WORK.title}
+            </Link>
+            <Link
+              prefetch={true}
+              href={LOGOMENU.url}
+              className="font-semibold text-white"
+            >
               {LOGOMENU.as}
             </Link>
-            <Link href={GALLERY.url}>{GALLERY.title}</Link>
+            <Link //
+              prefetch={true}
+              href={GALLERY.url}
+              className={
+                majorPathname === GALLERY.url ? "text-white" : "text-gray-400"
+              }
+            >
+              {GALLERY.title}
+            </Link>
           </div>
-          <div className="pr-header-margin flex h-full w-1/4 items-center justify-end gap-5">
-            <Link href={GUESTBOOK.url}>
+          <div className="flex h-full w-1/4 items-center justify-end gap-5 pr-header-margin">
+            <Link prefetch={true} href={GUESTBOOK.url}>
               <UserIcon color="white" size={22} />
             </Link>
-            <Link href={SIGNIN.url}>
+            <Link prefetch={true} href={SIGNIN.url}>
               <BookIcon color="white" size={20} />
             </Link>
             <button>

--- a/src/components/header/logo/index.tsx
+++ b/src/components/header/logo/index.tsx
@@ -37,17 +37,19 @@ const Logo = () => {
 
   return (
     <div
-      className="mb-2 flex w-fit translate-y-0.5 cursor-pointer items-center gap-2 font-display"
+      className="flex w-fit cursor-pointer items-center gap-2"
       onMouseOver={handleMouseOver}
     >
       <Link
         href="/"
         onClick={() => router.push("/")}
-        className="text-24 font-bold"
+        className="font-semibold text-white"
       >
         Bumang
       </Link>
-      {isVisible && <span className="translate-y-0.5 text-12">{status}</span>}
+      {isVisible && (
+        <span className="translate-y-0.5 text-12 text-white">{status}</span>
+      )}
     </div>
   );
 };

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,3 +1,4 @@
 export { default as Header } from "./header";
 export { default as StickyToolbar } from "./common/stickyToolbar";
 export { default as Tabbar } from "./common/tabbar";
+export { default as ItemListDeck } from "./lists";

--- a/src/components/lists/index.tsx
+++ b/src/components/lists/index.tsx
@@ -1,32 +1,19 @@
 "use client";
 
-import { ListType, SortType } from "@/types/item";
-import { useState } from "react";
+import ListItemView from "./itemList/listItemView";
+import GridItemView from "./itemList/gridItemView";
 
-export const ListItemView = () => {
-  return <div></div>;
-};
-
-export const GridItemView = () => {
-  return <div></div>;
-};
+import useQueryProps from "@/hooks/useQueryProps";
 
 const ItemListDeck = () => {
-  const [view, setView] = useState<ListType>("List");
-  const [sort, setSort] = useState<SortType>("Recent");
+  const { list } = useQueryProps();
 
-  const handleView = (to: ListType) => {
-    setView(to);
-  };
-
-  const handleSort = (to: SortType) => {
-    setSort(to);
-  };
+  console.log(list, "list????");
 
   return (
     <div className="">
-      {view === "List" && <ListItemView />}
-      {view === "Grid" && <GridItemView />}
+      {(list === "list" || !list) && <ListItemView />}
+      {list === "grid" && <GridItemView />}
     </div>
   );
 };

--- a/src/components/lists/itemList/gridItemView.tsx
+++ b/src/components/lists/itemList/gridItemView.tsx
@@ -1,0 +1,5 @@
+const GridItemView = () => {
+  return <div className="h-[200px] w-full bg-red text-white">GridItemView</div>;
+};
+
+export default GridItemView;

--- a/src/components/lists/itemList/listItemView.tsx
+++ b/src/components/lists/itemList/listItemView.tsx
@@ -1,0 +1,10 @@
+const ListItemView = () => {
+  return (
+    <div className="h-[300px] w-full rounded-12 border border-white">
+      <div></div>
+      <span></span>
+    </div>
+  );
+};
+
+export default ListItemView;

--- a/src/constants/menuTree.ts
+++ b/src/constants/menuTree.ts
@@ -4,6 +4,10 @@ export const menus: MenuType[] = [
   { title: "Landing", url: "/", as: "Bumang" },
   { title: "Guest Book", url: "/guest-book" },
   {
+    title: "Sign In",
+    url: "/signin",
+  },
+  {
     title: "Work",
     url: "/work",
     subMenu: [
@@ -18,20 +22,6 @@ export const menus: MenuType[] = [
       {
         title: "Playground",
         url: "/playground",
-      },
-      {
-        title: "log",
-        url: "/log",
-        subMenu: [
-          {
-            title: "Life",
-            url: "/life",
-          },
-          {
-            title: "Dev",
-            url: "/dev",
-          },
-        ],
       },
     ],
   },
@@ -54,7 +44,21 @@ export const menus: MenuType[] = [
     ],
   },
   {
-    title: "Sign In",
-    url: "/signin",
+    title: "Log",
+    url: "/log",
+    subMenu: [
+      {
+        title: "All",
+        url: "/",
+      },
+      {
+        title: "Dev",
+        url: "/dev",
+      },
+      {
+        title: "Life",
+        url: "/life",
+      },
+    ],
   },
 ] as const;

--- a/src/hooks/useQueryProps.ts
+++ b/src/hooks/useQueryProps.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+const useQueryProps = () => {
+  const searchParams = useSearchParams();
+  const list = searchParams.get("list");
+  const sort = searchParams.get("sort");
+
+  return {
+    list,
+    sort,
+  };
+};
+
+export default useQueryProps;


### PR DESCRIPTION
한 일
- 개별 로그
- 메뉴 중앙 정렬
- 모든 라우트에 Sticky Tabbar 적용
- pathname / queryString 등을 가공하여 메뉴 로직에 사용할 수 있는 custom hook 개발

close #4 